### PR TITLE
Recognitions: update for python3 + fosdem template

### DIFF
--- a/recognition/example_recognition_input.csv
+++ b/recognition/example_recognition_input.csv
@@ -1,2 +1,4 @@
-#"Team / Component","OBS Username (also used to get email)","Recognition Text",
+#"Team / Component / or any random string","OBS Username or 'Na Me <user@domain>''","Recognition Text",
 "Package A",lkocman,"You're being recognized for your contributions to package A. This is a custom text that will substitute __TEXT__ in email template passed to the recognition_emails_from_csv.py",
+"fosdem",lkocman,""
+"example",Lubos Kocman <example@domain>,""

--- a/recognition/recognition_fosdem.html
+++ b/recognition/recognition_fosdem.html
@@ -1,0 +1,59 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"><table border="0" cellpadding="0" cellspacing="0">
+        <!-- Work on this recognition effort is tracked here  https://github.com/openSUSE/artwork/pull/46 -->
+    </head>
+    <body>
+    <tbody>
+        <tr>
+            <td align="left" valign="top">
+            <table border="0" cellpadding="0" cellspacing="10" style="border:2px #173f4f solid;" width="530">
+                <tbody>
+                    <tr>
+			    <td align="center" margin="0" padding="0" valign="top"><img alt="e-Thank you for representing openSUSE at FOSDEM"  src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/FOSDEM_logo.svg/2034px-FOSDEM_logo.svg.png" width="400px" /></td>
+          <!-- for local testing <td align="center" margin="0" padding="0" valign="top"><img alt="You took the Leap to 15.3!"  src="../banners/png/banner-you-took-the-leap.png" width="530px" /></td> -->
+                    </tr>
+                    <tr width="530">
+                        <td align="left" style="font-family:'Source Sans Pro',sans-serif; font-size:18px; color:#000; padding:0px;" valign="top" width="530">
+                        <table border="0" cellpadding="10" cellspacing="0" style="margin-bottom:10px;" width="530">
+                            <tbody>
+                                <tr>
+                                    <td align="left" style="font-family:'Source Sans Pro',sans-serif;; font-size:18px; color:#000; padding:0px;" valign="top">
+
+<p style="font-family:'Source Sans Pro',sans-serif; color:#000; font-size:18px; line-height:24px;">
+<br/>
+<p>Dear __USER__</p>
+
+<p>We would like to recognize you for representing openSUSE at our FOSDEM 2023 booth.<strong>
+<br/><br/><em>You have done an exceptional job promoting the projects and helped to make our booth one of the most exciting places at the conference.</em></strong></p>
+
+<p><strong><em>
+__TEXT__
+</em></strong></p>
+
+<p><strong><em>​</em></strong></p>
+
+
+<p>Make sure to have a look at upcoming booth <a href="https://en.opensuse.org/openSUSE:Organising_a_booth">events</a> where we'd appreciate your help as well.</p>
+<p>We hope to see you at the booth again next year!</p>
+
+<p>Thank you</p>
+
+<p>openSUSE Release team</p>
+<img alt="openSUSE Logo" width="30" height="30" src="https://github.com/openSUSE/artwork/raw/master/logos/buttons/button-monochrome.png" />
+</p>
+<p style="font-style:italic;font-size: 50%;">Make sure to load all the cool images for this recognition. E.g. by pressing Ctrl+i in Evolution.</p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/recognition/recognition_leap_15.3_example_individual.htm
+++ b/recognition/recognition_leap_15.3_example_individual.htm
@@ -40,6 +40,7 @@ __TEXT__
 <p>openSUSE Release team</p>
 <img alt="openSUSE Logo" width="30" height="30" src="https://github.com/openSUSE/artwork/raw/master/logos/buttons/button-monochrome.png" />
 </p>
+<p style="font-style:italic;font-size: 50%;">Make sure to load all the cool images for this recognition. E.g. by pressing Ctrl+i in Evolution.</p>
                                     </td>
                                 </tr>
                             </tbody>

--- a/recognition/recognition_leap_15.3_retro_example_individual.htm
+++ b/recognition/recognition_leap_15.3_retro_example_individual.htm
@@ -39,6 +39,7 @@ __TEXT__
 
 <p>openSUSE Release team</p>
 <img alt="openSUSE Logo" width="30" height="30" src="https://github.com/openSUSE/artwork/raw/master/logos/buttons/button-monochrome.png" />
+<p style="font-style:italic;font-size: 50%;">Make sure to load all the cool images for this recognition. E.g. by pressing Ctrl+i in Evolution.</p>
 </p>
                                     </td>
                                 </tr>


### PR DESCRIPTION
New template for FOSDEM and python3 update

I did agree with Doug to use marketing email as "From". Recognitions were already sent. Input file for FOSDEM was not disclosed on purpose, so it's not part of the PR.

This template could be used for recognition of booth crew for upcoming conferences.



![recognition](https://user-images.githubusercontent.com/510119/217050473-df4649f7-f309-4d3e-bdb5-244759e5c162.png)

