### PR TITLE
recognition: use comma as default delimiter

### DIFF
--- a/recognition/recognition_emails_from_csv.py
+++ b/recognition/recognition_emails_from_csv.py
@@ -11,7 +11,7 @@ import email.utils
 
 from retry import retry
 
-DEFAULT_DELIMITER = ";"
+DEFAULT_DELIMITER = ","
 
 
 # map of default config entries


### PR DESCRIPTION
Use comma instead of semicolon. Otherwise it's bit counterintuitive since our examples are using comma.